### PR TITLE
feat: Automate strategy conversion from LaTeX to Python

### DIFF
--- a/LK_RB_Synthesis/generate_skeletons.py
+++ b/LK_RB_Synthesis/generate_skeletons.py
@@ -1,0 +1,71 @@
+import json
+import os
+import re
+
+def to_snake_case(name):
+    """Converts a string to snake_case."""
+    name = re.sub(r'[^a-zA-Z0-9\s]', '', name)
+    return '_'.join(name.lower().split())
+
+def generate_skeletons(json_path, output_dir):
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    with open(json_path, 'r') as f:
+        strategies = json.load(f)
+
+    for strategy in strategies:
+        name = strategy['Name']
+        description = strategy['Description']
+        cognitive_steps = strategy['Cognitive_Steps']
+
+        # Generate a filename from the name
+        filename = f"{to_snake_case(name)}.py"
+        filepath = os.path.join(output_dir, filename)
+
+        # Generate the class name
+        class_name = ''.join(word.title() for word in name.replace('(', '').replace(')', '').split())
+        class_name = re.sub(r'[^a-zA-Z0-9]', '', class_name)
+        if not class_name.endswith("Automaton"):
+            class_name += "Automaton"
+
+        # Generate the python code for the skeleton
+        code = f"""
+from src.automata.BaseAutomaton import BaseAutomaton
+from src.analysis.MUA_Metadata import StrategyMetadata
+
+class {class_name}(BaseAutomaton):
+    _metadata = {{
+        "Name": "{name}",
+        "Description": "{description}",
+        "Cognitive Steps": {cognitive_steps},
+        "Examples": []
+    }}
+
+    @property
+    def metadata(self) -> StrategyMetadata:
+        return StrategyMetadata(**self._metadata)
+
+    def execute_q_start(self):
+        # Initial state logic
+        pass
+"""
+
+        for step in cognitive_steps:
+            # Skip q_start as it's already defined
+            if step == 'q_start':
+                continue
+            # Clean the step name to be a valid method name
+            method_name = step.replace('q_', '')
+            code += f"""
+    def execute_{step}(self):
+        # Logic for {method_name}
+        pass
+"""
+
+        with open(filepath, 'w') as f:
+            f.write(code)
+        print(f"Generated skeleton for {name} at {filepath}")
+
+if __name__ == "__main__":
+    generate_skeletons('strategies.json', 'strategies')

--- a/LK_RB_Synthesis/parse_latex.py
+++ b/LK_RB_Synthesis/parse_latex.py
@@ -1,0 +1,146 @@
+import re
+import json
+
+def parse_latex(file_path):
+    with open(file_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    # Find all sections, which represent strategies
+    section_pattern = re.compile(r'\\section\{(.+?)\}(.+?)(?=\\section|\Z)', re.DOTALL)
+    sections = section_pattern.findall(content)
+
+    strategies = []
+    for name, section_content in sections:
+        name = name.strip().replace('\n', ' ')
+
+        # List of sections to skip
+        if name in ["Conceptual Dependency Graph (Narrative)",
+                     "Temporal Dynamics Summary",
+                     "Glossary of Symbols",
+                     "Hermeneutic Calculator: Strategy Formalizations",
+                     "Counting and Counting On"]: # Skip the first one as it's a primitive
+            continue
+
+        # Extract the description
+        description_match = re.search(r'\\textbf\{Description\.\}\s*(.+?)(?=\\textbf|\\begin\{longtable\}|\\begin\{center\}|\Z)', section_content, re.DOTALL)
+        description = "No description found."
+        if description_match:
+            description = description_match.group(1).strip()
+            # Clean up LaTeX commands from description
+            description = re.sub(r'\s*\\(.+?)\s*', '', description)
+            description = re.sub(r'[\{\}\$]', '', description)
+
+
+        # Extract cognitive steps from the Q = {...} definition
+        cognitive_steps = []
+        q_match = re.search(r'Q\s*=\s*\\\{(.+?)\\\}', section_content)
+        if q_match:
+            states_str = q_match.group(1)
+            # Remove latex commands for states and clean up
+            states_str = re.sub(r'q_\{(.+?)\}', r'q_\1', states_str)
+            states = [s.strip().replace('\\', '') for s in states_str.split(',')]
+            # We want the state names without the 'q_' prefix for the methods
+            cognitive_steps = [s for s in states if s != 'q_accept']
+
+        # Handle special cases
+        if "Subtraction Chunking" in name:
+            orientation_pattern = re.compile(r'\\textbf\{([ABC])\.\s*(.+?)\}.+?\(V = \\{(.+?)\\}\)', re.DOTALL)
+            orientations = orientation_pattern.findall(section_content)
+            for _letter, desc, registers in orientations:
+                full_name = f"Subtraction Chunking ({desc.strip()})"
+                # Infer steps from registers
+                steps = ['q_init']
+                reg_list = [r.strip() for r in registers.split(',')]
+                if 'Chunk' in reg_list or 'S_{rem}' in reg_list:
+                    steps.append('q_chunk')
+
+                strategies.append({
+                    "Name": full_name,
+                    "Description": desc.strip().replace('.', ''),
+                    "Cognitive_Steps": steps,
+                    "Examples": []
+                })
+            continue
+
+        if "Subtraction COBO / CBBO" in name:
+            strategies.append({
+                "Name": "Subtraction COBO (Missing Addend)",
+                "Description": "Start at S, perform base jumps toward M (without overshoot), then ones; distance accumulated is D.",
+                "Cognitive_Steps": ["q_init", "q_add_bases", "q_add_ones"],
+                "Examples": []
+            })
+            strategies.append({
+                "Name": "Subtraction CBBO (Counting Back)",
+                "Description": "Start at M, subtract base units (from decomposed S) then ones; final position is D.",
+                "Cognitive_Steps": ["q_init", "q_sub_bases", "q_sub_ones"],
+                "Examples": []
+            })
+            continue
+
+        # If we have a valid strategy, add it to the list
+        if cognitive_steps:
+             strategies.append({
+                "Name": name,
+                "Description": description,
+                "Cognitive_Steps": cognitive_steps,
+                "Examples": []
+            })
+
+    return strategies
+
+if __name__ == "__main__":
+    strategies = parse_latex('HC_GEM.tex')
+    # Manually add the last few strategies that are not easily parsable
+    strategies.append({
+        "Name": "Commutative Reasoning (Multiplication Optimization)",
+        "Description": "For A x B, evaluate heuristic difficulty of (A,B) vs (B,A); select orientation minimizing cognitive load, then perform iterative addition.",
+        "Cognitive_Steps": ["q_evaluate", "q_repackage", "q_calc"],
+        "Examples": []
+    })
+    strategies.append({
+        "Name": "Coordinating Two Counts (C2C)",
+        "Description": "Foundational multiplication: nested counting---items within group, groups within total.",
+        "Cognitive_Steps": ["q_init", "q_checkG", "q_countItems", "q_nextGroup"],
+        "Examples": []
+    })
+    strategies.append({
+        "Name": "Conversion to Bases and Ones (CBO Multiplication)",
+        "Description": "Redistribute units among groups so that many groups become exact base multiples, leaving a compact residual.",
+        "Cognitive_Steps": ["q_init", "q_select_source", "q_transfer", "q_finalize"],
+        "Examples": []
+    })
+    strategies.append({
+        "Name": "Distributive Reasoning (Multiplication)",
+        "Description": "Decompose S = S1 + S2, compute N*S1 and N*S2, then sum.",
+        "Cognitive_Steps": ["q_split", "q_P1", "q_P2", "q_sum"],
+        "Examples": []
+    })
+    strategies.append({
+        "Name": "Dealing by Ones (Division -- Sharing)",
+        "Description": "Partitive division: distribute single units round-robin into N groups until total T exhausted.",
+        "Cognitive_Steps": ["q_init", "q_deal"],
+        "Examples": []
+    })
+    strategies.append({
+        "Name": "Inverse Distributive Reasoning (Division)",
+        "Description": "Measurement division T / S: decompose T into known multiples of S.",
+        "Cognitive_Steps": ["q_init", "q_search", "q_apply"],
+        "Examples": []
+    })
+    strategies.append({
+        "Name": "Using Commutative Reasoning (Division via Iterated Accumulation)",
+        "Description": "For E / G: iteratively accumulate G until total E reached; iteration count is quotient.",
+        "Cognitive_Steps": ["q_init", "q_iterate", "q_check"],
+        "Examples": []
+    })
+    strategies.append({
+        "Name": "Conversion to Groups Other than Bases (CGOB Division)",
+        "Description": "Leverage base decomposition of dividend T and analysis of base/divisor relation.",
+        "Cognitive_Steps": ["q_init", "q_analyze", "q_processBases", "q_combineR", "q_processR"],
+        "Examples": []
+    })
+
+
+    with open('strategies.json', 'w') as f:
+        json.dump(strategies, f, indent=4)
+    print(f"Successfully parsed {len(strategies)} strategies and saved to strategies.json")

--- a/LK_RB_Synthesis/strategies.json
+++ b/LK_RB_Synthesis/strategies.json
@@ -1,0 +1,128 @@
+[
+    {
+        "Name": "Counting and Counting On",
+        "Description": "Sequential unit counting within a bounded base-10 place-value structure.",
+        "Cognitive_Steps": ["q_start", "q_idle", "q_inc_tens", "q_inc_hundreds", "q_halt"],
+        "Examples": []
+    },
+    {
+        "Name": "Rearranging to Make Bases (RMB)",
+        "Description": "For A + B, identify gap K from A to next base, decompose B = K + R, form A' = A + K, then compute A' + R.",
+        "Cognitive_Steps": ["q_start", "q_calcK", "q_decompose", "q_recombine"],
+        "Examples": []
+    },
+    {
+        "Name": "COBO (Counting On by Bases then Ones)",
+        "Description": "For A + B, decompose B = b * Base + r; iterate base jumps (+Base) then unit steps (+1).",
+        "Cognitive_Steps": ["q_start", "q_initialize", "q_add_bases", "q_add_ones"],
+        "Examples": []
+    },
+    {
+        "Name": "Rounding and Adjusting (Addition)",
+        "Description": "Select addend closer to next base: round up A -> A' = A + K, compute A' + B, then adjust back: (A' + B) - K.",
+        "Cognitive_Steps": ["q_start", "q_calcK", "q_add", "q_adjust"],
+        "Examples": []
+    },
+    {
+        "Name": "Chunking (Addition)",
+        "Description": "Decompose B into large base chunk + strategic residual chunks to force successive bases.",
+        "Cognitive_Steps": ["q_init", "q_addBase", "q_calcK", "q_applyK", "q_finishR"],
+        "Examples": []
+    },
+    {
+        "Name": "Subtraction Chunking (Backwards by Part)",
+        "Description": "Sequentially subtract decomposed parts of S from M.",
+        "Cognitive_Steps": ["q_init", "q_chunk"],
+        "Examples": []
+    },
+    {
+        "Name": "Subtraction Chunking (Forwards from Part)",
+        "Description": "Treat as S + D = M; Count Up (RMB logic) accumulating D.",
+        "Cognitive_Steps": ["q_init", "q_chunk"],
+        "Examples": []
+    },
+    {
+        "Name": "Subtraction Chunking (Backwards to Part)",
+        "Description": "Count Back from M toward S using strategic base landings; accumulate distance.",
+        "Cognitive_Steps": ["q_init", "q_chunk"],
+        "Examples": []
+    },
+    {
+        "Name": "Subtraction COBO (Missing Addend)",
+        "Description": "Start at S, perform base jumps toward M, then ones; distance accumulated is D.",
+        "Cognitive_Steps": ["q_init", "q_add_bases", "q_add_ones"],
+        "Examples": []
+    },
+    {
+        "Name": "Subtraction CBBO (Counting Back)",
+        "Description": "Start at M, subtract base units from decomposed S, then ones.",
+        "Cognitive_Steps": ["q_init", "q_sub_bases", "q_sub_ones"],
+        "Examples": []
+    },
+    {
+        "Name": "Subtraction Decomposition (Borrowing)",
+        "Description": "Subtract higher place, detect insufficiency, borrow from higher unit, then subtract ones.",
+        "Cognitive_Steps": ["q_init", "q_sub_bases", "q_check_ones", "q_decompose", "q_sub_ones"],
+        "Examples": []
+    },
+    {
+        "Name": "Subtraction Rounding and Adjusting",
+        "Description": "Dual rounding yields simplified M' - S', then contrasting compensations.",
+        "Cognitive_Steps": ["q_start", "q_roundM", "q_roundS", "q_subtract", "q_adjustM", "q_adjustS"],
+        "Examples": []
+    },
+    {
+        "Name": "Subtraction Sliding (Constant Difference)",
+        "Description": "Find K so that S + K is a base number; compute (M + K) - (S + K).",
+        "Cognitive_Steps": ["q_start", "q_calcK", "q_slide", "q_subtract"],
+        "Examples": []
+    },
+    {
+        "Name": "Commutative Reasoning (Multiplication)",
+        "Description": "Select orientation (A x B vs B x A) minimizing cognitive load.",
+        "Cognitive_Steps": ["q_evaluate", "q_repackage", "q_calc"],
+        "Examples": []
+    },
+    {
+        "Name": "Coordinating Two Counts (C2C)",
+        "Description": "Nested counting: items within group, groups within total.",
+        "Cognitive_Steps": ["q_init", "q_checkG", "q_countItems", "q_nextGroup"],
+        "Examples": []
+    },
+    {
+        "Name": "Conversion to Bases and Ones (CBO Multiplication)",
+        "Description": "Redistribute units among groups to manufacture base units.",
+        "Cognitive_Steps": ["q_init", "q_select_source", "q_transfer", "q_finalize"],
+        "Examples": []
+    },
+    {
+        "Name": "Distributive Reasoning (Multiplication)",
+        "Description": "Decompose S = S1 + S2, compute N*S1 and N*S2, then sum.",
+        "Cognitive_Steps": ["q_split", "q_P1", "q_P2", "q_sum"],
+        "Examples": []
+    },
+    {
+        "Name": "Dealing by Ones (Division - Sharing)",
+        "Description": "Distribute single units round-robin into N groups until total T exhausted.",
+        "Cognitive_Steps": ["q_init", "q_deal"],
+        "Examples": []
+    },
+    {
+        "Name": "Inverse Distributive Reasoning (Division)",
+        "Description": "Decompose T into known multiples of S: T = sum(m_i * S); quotient = sum(m_i).",
+        "Cognitive_Steps": ["q_init", "q_search", "q_apply"],
+        "Examples": []
+    },
+    {
+        "Name": "Using Commutative Reasoning (Division)",
+        "Description": "For E / G: iteratively accumulate G until total E reached; iteration count is quotient.",
+        "Cognitive_Steps": ["q_init", "q_iterate", "q_check"],
+        "Examples": []
+    },
+    {
+        "Name": "Conversion to Groups Other than Bases (CGOB Division)",
+        "Description": "Leverage base decomposition of dividend T and analysis of base/divisor relation.",
+        "Cognitive_Steps": ["q_init", "q_analyze", "q_processBases", "q_combineR", "q_processR"],
+        "Examples": []
+    }
+]

--- a/LK_RB_Synthesis/strategies/chunking_addition.py
+++ b/LK_RB_Synthesis/strategies/chunking_addition.py
@@ -1,0 +1,39 @@
+
+from src.automata.BaseAutomaton import BaseAutomaton
+from src.analysis.MUA_Metadata import StrategyMetadata
+
+class ChunkingAdditionAutomaton(BaseAutomaton):
+    _metadata = {
+        "Name": "Chunking (Addition)",
+        "Description": "Decompose B into large base chunk + strategic residual chunks to force successive bases.",
+        "Cognitive Steps": ['q_init', 'q_addBase', 'q_calcK', 'q_applyK', 'q_finishR'],
+        "Examples": []
+    }
+
+    @property
+    def metadata(self) -> StrategyMetadata:
+        return StrategyMetadata(**self._metadata)
+
+    def execute_q_start(self):
+        # Initial state logic
+        pass
+
+    def execute_q_init(self):
+        # Logic for init
+        pass
+
+    def execute_q_addBase(self):
+        # Logic for addBase
+        pass
+
+    def execute_q_calcK(self):
+        # Logic for calcK
+        pass
+
+    def execute_q_applyK(self):
+        # Logic for applyK
+        pass
+
+    def execute_q_finishR(self):
+        # Logic for finishR
+        pass

--- a/LK_RB_Synthesis/strategies/cobo_counting_on_by_bases_then_ones.py
+++ b/LK_RB_Synthesis/strategies/cobo_counting_on_by_bases_then_ones.py
@@ -1,0 +1,31 @@
+
+from src.automata.BaseAutomaton import BaseAutomaton
+from src.analysis.MUA_Metadata import StrategyMetadata
+
+class CoboCountingOnByBasesThenOnesAutomaton(BaseAutomaton):
+    _metadata = {
+        "Name": "COBO (Counting On by Bases then Ones)",
+        "Description": "For A + B, decompose B = b * Base + r; iterate base jumps (+Base) then unit steps (+1).",
+        "Cognitive Steps": ['q_start', 'q_initialize', 'q_add_bases', 'q_add_ones'],
+        "Examples": []
+    }
+
+    @property
+    def metadata(self) -> StrategyMetadata:
+        return StrategyMetadata(**self._metadata)
+
+    def execute_q_start(self):
+        # Initial state logic
+        pass
+
+    def execute_q_initialize(self):
+        # Logic for initialize
+        pass
+
+    def execute_q_add_bases(self):
+        # Logic for add_bases
+        pass
+
+    def execute_q_add_ones(self):
+        # Logic for add_ones
+        pass

--- a/LK_RB_Synthesis/strategies/commutative_reasoning_multiplication.py
+++ b/LK_RB_Synthesis/strategies/commutative_reasoning_multiplication.py
@@ -1,0 +1,31 @@
+
+from src.automata.BaseAutomaton import BaseAutomaton
+from src.analysis.MUA_Metadata import StrategyMetadata
+
+class CommutativeReasoningMultiplicationAutomaton(BaseAutomaton):
+    _metadata = {
+        "Name": "Commutative Reasoning (Multiplication)",
+        "Description": "Select orientation (A x B vs B x A) minimizing cognitive load.",
+        "Cognitive Steps": ['q_evaluate', 'q_repackage', 'q_calc'],
+        "Examples": []
+    }
+
+    @property
+    def metadata(self) -> StrategyMetadata:
+        return StrategyMetadata(**self._metadata)
+
+    def execute_q_start(self):
+        # Initial state logic
+        pass
+
+    def execute_q_evaluate(self):
+        # Logic for evaluate
+        pass
+
+    def execute_q_repackage(self):
+        # Logic for repackage
+        pass
+
+    def execute_q_calc(self):
+        # Logic for calc
+        pass

--- a/LK_RB_Synthesis/strategies/conversion_to_bases_and_ones_cbo_multiplication.py
+++ b/LK_RB_Synthesis/strategies/conversion_to_bases_and_ones_cbo_multiplication.py
@@ -1,0 +1,35 @@
+
+from src.automata.BaseAutomaton import BaseAutomaton
+from src.analysis.MUA_Metadata import StrategyMetadata
+
+class ConversionToBasesAndOnesCboMultiplicationAutomaton(BaseAutomaton):
+    _metadata = {
+        "Name": "Conversion to Bases and Ones (CBO Multiplication)",
+        "Description": "Redistribute units among groups to manufacture base units.",
+        "Cognitive Steps": ['q_init', 'q_select_source', 'q_transfer', 'q_finalize'],
+        "Examples": []
+    }
+
+    @property
+    def metadata(self) -> StrategyMetadata:
+        return StrategyMetadata(**self._metadata)
+
+    def execute_q_start(self):
+        # Initial state logic
+        pass
+
+    def execute_q_init(self):
+        # Logic for init
+        pass
+
+    def execute_q_select_source(self):
+        # Logic for select_source
+        pass
+
+    def execute_q_transfer(self):
+        # Logic for transfer
+        pass
+
+    def execute_q_finalize(self):
+        # Logic for finalize
+        pass

--- a/LK_RB_Synthesis/strategies/conversion_to_groups_other_than_bases_cgob_division.py
+++ b/LK_RB_Synthesis/strategies/conversion_to_groups_other_than_bases_cgob_division.py
@@ -1,0 +1,39 @@
+
+from src.automata.BaseAutomaton import BaseAutomaton
+from src.analysis.MUA_Metadata import StrategyMetadata
+
+class ConversionToGroupsOtherThanBasesCgobDivisionAutomaton(BaseAutomaton):
+    _metadata = {
+        "Name": "Conversion to Groups Other than Bases (CGOB Division)",
+        "Description": "Leverage base decomposition of dividend T and analysis of base/divisor relation.",
+        "Cognitive Steps": ['q_init', 'q_analyze', 'q_processBases', 'q_combineR', 'q_processR'],
+        "Examples": []
+    }
+
+    @property
+    def metadata(self) -> StrategyMetadata:
+        return StrategyMetadata(**self._metadata)
+
+    def execute_q_start(self):
+        # Initial state logic
+        pass
+
+    def execute_q_init(self):
+        # Logic for init
+        pass
+
+    def execute_q_analyze(self):
+        # Logic for analyze
+        pass
+
+    def execute_q_processBases(self):
+        # Logic for processBases
+        pass
+
+    def execute_q_combineR(self):
+        # Logic for combineR
+        pass
+
+    def execute_q_processR(self):
+        # Logic for processR
+        pass

--- a/LK_RB_Synthesis/strategies/coordinating_two_counts_c2c.py
+++ b/LK_RB_Synthesis/strategies/coordinating_two_counts_c2c.py
@@ -1,0 +1,35 @@
+
+from src.automata.BaseAutomaton import BaseAutomaton
+from src.analysis.MUA_Metadata import StrategyMetadata
+
+class CoordinatingTwoCountsC2CAutomaton(BaseAutomaton):
+    _metadata = {
+        "Name": "Coordinating Two Counts (C2C)",
+        "Description": "Nested counting: items within group, groups within total.",
+        "Cognitive Steps": ['q_init', 'q_checkG', 'q_countItems', 'q_nextGroup'],
+        "Examples": []
+    }
+
+    @property
+    def metadata(self) -> StrategyMetadata:
+        return StrategyMetadata(**self._metadata)
+
+    def execute_q_start(self):
+        # Initial state logic
+        pass
+
+    def execute_q_init(self):
+        # Logic for init
+        pass
+
+    def execute_q_checkG(self):
+        # Logic for checkG
+        pass
+
+    def execute_q_countItems(self):
+        # Logic for countItems
+        pass
+
+    def execute_q_nextGroup(self):
+        # Logic for nextGroup
+        pass

--- a/LK_RB_Synthesis/strategies/counting_and_counting_on.py
+++ b/LK_RB_Synthesis/strategies/counting_and_counting_on.py
@@ -1,0 +1,35 @@
+
+from src.automata.BaseAutomaton import BaseAutomaton
+from src.analysis.MUA_Metadata import StrategyMetadata
+
+class CountingAndCountingOnAutomaton(BaseAutomaton):
+    _metadata = {
+        "Name": "Counting and Counting On",
+        "Description": "Sequential unit counting within a bounded base-10 place-value structure.",
+        "Cognitive Steps": ['q_start', 'q_idle', 'q_inc_tens', 'q_inc_hundreds', 'q_halt'],
+        "Examples": []
+    }
+
+    @property
+    def metadata(self) -> StrategyMetadata:
+        return StrategyMetadata(**self._metadata)
+
+    def execute_q_start(self):
+        # Initial state logic
+        pass
+
+    def execute_q_idle(self):
+        # Logic for idle
+        pass
+
+    def execute_q_inc_tens(self):
+        # Logic for inc_tens
+        pass
+
+    def execute_q_inc_hundreds(self):
+        # Logic for inc_hundreds
+        pass
+
+    def execute_q_halt(self):
+        # Logic for halt
+        pass

--- a/LK_RB_Synthesis/strategies/dealing_by_ones_division_sharing.py
+++ b/LK_RB_Synthesis/strategies/dealing_by_ones_division_sharing.py
@@ -1,0 +1,27 @@
+
+from src.automata.BaseAutomaton import BaseAutomaton
+from src.analysis.MUA_Metadata import StrategyMetadata
+
+class DealingByOnesDivisionSharingAutomaton(BaseAutomaton):
+    _metadata = {
+        "Name": "Dealing by Ones (Division - Sharing)",
+        "Description": "Distribute single units round-robin into N groups until total T exhausted.",
+        "Cognitive Steps": ['q_init', 'q_deal'],
+        "Examples": []
+    }
+
+    @property
+    def metadata(self) -> StrategyMetadata:
+        return StrategyMetadata(**self._metadata)
+
+    def execute_q_start(self):
+        # Initial state logic
+        pass
+
+    def execute_q_init(self):
+        # Logic for init
+        pass
+
+    def execute_q_deal(self):
+        # Logic for deal
+        pass

--- a/LK_RB_Synthesis/strategies/distributive_reasoning_multiplication.py
+++ b/LK_RB_Synthesis/strategies/distributive_reasoning_multiplication.py
@@ -1,0 +1,35 @@
+
+from src.automata.BaseAutomaton import BaseAutomaton
+from src.analysis.MUA_Metadata import StrategyMetadata
+
+class DistributiveReasoningMultiplicationAutomaton(BaseAutomaton):
+    _metadata = {
+        "Name": "Distributive Reasoning (Multiplication)",
+        "Description": "Decompose S = S1 + S2, compute N*S1 and N*S2, then sum.",
+        "Cognitive Steps": ['q_split', 'q_P1', 'q_P2', 'q_sum'],
+        "Examples": []
+    }
+
+    @property
+    def metadata(self) -> StrategyMetadata:
+        return StrategyMetadata(**self._metadata)
+
+    def execute_q_start(self):
+        # Initial state logic
+        pass
+
+    def execute_q_split(self):
+        # Logic for split
+        pass
+
+    def execute_q_P1(self):
+        # Logic for P1
+        pass
+
+    def execute_q_P2(self):
+        # Logic for P2
+        pass
+
+    def execute_q_sum(self):
+        # Logic for sum
+        pass

--- a/LK_RB_Synthesis/strategies/inverse_distributive_reasoning_division.py
+++ b/LK_RB_Synthesis/strategies/inverse_distributive_reasoning_division.py
@@ -1,0 +1,31 @@
+
+from src.automata.BaseAutomaton import BaseAutomaton
+from src.analysis.MUA_Metadata import StrategyMetadata
+
+class InverseDistributiveReasoningDivisionAutomaton(BaseAutomaton):
+    _metadata = {
+        "Name": "Inverse Distributive Reasoning (Division)",
+        "Description": "Decompose T into known multiples of S: T = sum(m_i * S); quotient = sum(m_i).",
+        "Cognitive Steps": ['q_init', 'q_search', 'q_apply'],
+        "Examples": []
+    }
+
+    @property
+    def metadata(self) -> StrategyMetadata:
+        return StrategyMetadata(**self._metadata)
+
+    def execute_q_start(self):
+        # Initial state logic
+        pass
+
+    def execute_q_init(self):
+        # Logic for init
+        pass
+
+    def execute_q_search(self):
+        # Logic for search
+        pass
+
+    def execute_q_apply(self):
+        # Logic for apply
+        pass

--- a/LK_RB_Synthesis/strategies/rearranging_to_make_bases_rmb.py
+++ b/LK_RB_Synthesis/strategies/rearranging_to_make_bases_rmb.py
@@ -1,0 +1,31 @@
+
+from src.automata.BaseAutomaton import BaseAutomaton
+from src.analysis.MUA_Metadata import StrategyMetadata
+
+class RearrangingToMakeBasesRmbAutomaton(BaseAutomaton):
+    _metadata = {
+        "Name": "Rearranging to Make Bases (RMB)",
+        "Description": "For A + B, identify gap K from A to next base, decompose B = K + R, form A' = A + K, then compute A' + R.",
+        "Cognitive Steps": ['q_start', 'q_calcK', 'q_decompose', 'q_recombine'],
+        "Examples": []
+    }
+
+    @property
+    def metadata(self) -> StrategyMetadata:
+        return StrategyMetadata(**self._metadata)
+
+    def execute_q_start(self):
+        # Initial state logic
+        pass
+
+    def execute_q_calcK(self):
+        # Logic for calcK
+        pass
+
+    def execute_q_decompose(self):
+        # Logic for decompose
+        pass
+
+    def execute_q_recombine(self):
+        # Logic for recombine
+        pass

--- a/LK_RB_Synthesis/strategies/rounding_and_adjusting_addition.py
+++ b/LK_RB_Synthesis/strategies/rounding_and_adjusting_addition.py
@@ -1,0 +1,31 @@
+
+from src.automata.BaseAutomaton import BaseAutomaton
+from src.analysis.MUA_Metadata import StrategyMetadata
+
+class RoundingAndAdjustingAdditionAutomaton(BaseAutomaton):
+    _metadata = {
+        "Name": "Rounding and Adjusting (Addition)",
+        "Description": "Select addend closer to next base: round up A -> A' = A + K, compute A' + B, then adjust back: (A' + B) - K.",
+        "Cognitive Steps": ['q_start', 'q_calcK', 'q_add', 'q_adjust'],
+        "Examples": []
+    }
+
+    @property
+    def metadata(self) -> StrategyMetadata:
+        return StrategyMetadata(**self._metadata)
+
+    def execute_q_start(self):
+        # Initial state logic
+        pass
+
+    def execute_q_calcK(self):
+        # Logic for calcK
+        pass
+
+    def execute_q_add(self):
+        # Logic for add
+        pass
+
+    def execute_q_adjust(self):
+        # Logic for adjust
+        pass

--- a/LK_RB_Synthesis/strategies/subtraction_cbbo_counting_back.py
+++ b/LK_RB_Synthesis/strategies/subtraction_cbbo_counting_back.py
@@ -1,0 +1,31 @@
+
+from src.automata.BaseAutomaton import BaseAutomaton
+from src.analysis.MUA_Metadata import StrategyMetadata
+
+class SubtractionCbboCountingBackAutomaton(BaseAutomaton):
+    _metadata = {
+        "Name": "Subtraction CBBO (Counting Back)",
+        "Description": "Start at M, subtract base units from decomposed S, then ones.",
+        "Cognitive Steps": ['q_init', 'q_sub_bases', 'q_sub_ones'],
+        "Examples": []
+    }
+
+    @property
+    def metadata(self) -> StrategyMetadata:
+        return StrategyMetadata(**self._metadata)
+
+    def execute_q_start(self):
+        # Initial state logic
+        pass
+
+    def execute_q_init(self):
+        # Logic for init
+        pass
+
+    def execute_q_sub_bases(self):
+        # Logic for sub_bases
+        pass
+
+    def execute_q_sub_ones(self):
+        # Logic for sub_ones
+        pass

--- a/LK_RB_Synthesis/strategies/subtraction_chunking_backwards_by_part.py
+++ b/LK_RB_Synthesis/strategies/subtraction_chunking_backwards_by_part.py
@@ -1,0 +1,27 @@
+
+from src.automata.BaseAutomaton import BaseAutomaton
+from src.analysis.MUA_Metadata import StrategyMetadata
+
+class SubtractionChunkingBackwardsByPartAutomaton(BaseAutomaton):
+    _metadata = {
+        "Name": "Subtraction Chunking (Backwards by Part)",
+        "Description": "Sequentially subtract decomposed parts of S from M.",
+        "Cognitive Steps": ['q_init', 'q_chunk'],
+        "Examples": []
+    }
+
+    @property
+    def metadata(self) -> StrategyMetadata:
+        return StrategyMetadata(**self._metadata)
+
+    def execute_q_start(self):
+        # Initial state logic
+        pass
+
+    def execute_q_init(self):
+        # Logic for init
+        pass
+
+    def execute_q_chunk(self):
+        # Logic for chunk
+        pass

--- a/LK_RB_Synthesis/strategies/subtraction_chunking_backwards_to_part.py
+++ b/LK_RB_Synthesis/strategies/subtraction_chunking_backwards_to_part.py
@@ -1,0 +1,27 @@
+
+from src.automata.BaseAutomaton import BaseAutomaton
+from src.analysis.MUA_Metadata import StrategyMetadata
+
+class SubtractionChunkingBackwardsToPartAutomaton(BaseAutomaton):
+    _metadata = {
+        "Name": "Subtraction Chunking (Backwards to Part)",
+        "Description": "Count Back from M toward S using strategic base landings; accumulate distance.",
+        "Cognitive Steps": ['q_init', 'q_chunk'],
+        "Examples": []
+    }
+
+    @property
+    def metadata(self) -> StrategyMetadata:
+        return StrategyMetadata(**self._metadata)
+
+    def execute_q_start(self):
+        # Initial state logic
+        pass
+
+    def execute_q_init(self):
+        # Logic for init
+        pass
+
+    def execute_q_chunk(self):
+        # Logic for chunk
+        pass

--- a/LK_RB_Synthesis/strategies/subtraction_chunking_forwards_from_part.py
+++ b/LK_RB_Synthesis/strategies/subtraction_chunking_forwards_from_part.py
@@ -1,0 +1,27 @@
+
+from src.automata.BaseAutomaton import BaseAutomaton
+from src.analysis.MUA_Metadata import StrategyMetadata
+
+class SubtractionChunkingForwardsFromPartAutomaton(BaseAutomaton):
+    _metadata = {
+        "Name": "Subtraction Chunking (Forwards from Part)",
+        "Description": "Treat as S + D = M; Count Up (RMB logic) accumulating D.",
+        "Cognitive Steps": ['q_init', 'q_chunk'],
+        "Examples": []
+    }
+
+    @property
+    def metadata(self) -> StrategyMetadata:
+        return StrategyMetadata(**self._metadata)
+
+    def execute_q_start(self):
+        # Initial state logic
+        pass
+
+    def execute_q_init(self):
+        # Logic for init
+        pass
+
+    def execute_q_chunk(self):
+        # Logic for chunk
+        pass

--- a/LK_RB_Synthesis/strategies/subtraction_cobo_missing_addend.py
+++ b/LK_RB_Synthesis/strategies/subtraction_cobo_missing_addend.py
@@ -1,0 +1,31 @@
+
+from src.automata.BaseAutomaton import BaseAutomaton
+from src.analysis.MUA_Metadata import StrategyMetadata
+
+class SubtractionCoboMissingAddendAutomaton(BaseAutomaton):
+    _metadata = {
+        "Name": "Subtraction COBO (Missing Addend)",
+        "Description": "Start at S, perform base jumps toward M, then ones; distance accumulated is D.",
+        "Cognitive Steps": ['q_init', 'q_add_bases', 'q_add_ones'],
+        "Examples": []
+    }
+
+    @property
+    def metadata(self) -> StrategyMetadata:
+        return StrategyMetadata(**self._metadata)
+
+    def execute_q_start(self):
+        # Initial state logic
+        pass
+
+    def execute_q_init(self):
+        # Logic for init
+        pass
+
+    def execute_q_add_bases(self):
+        # Logic for add_bases
+        pass
+
+    def execute_q_add_ones(self):
+        # Logic for add_ones
+        pass

--- a/LK_RB_Synthesis/strategies/subtraction_decomposition_borrowing.py
+++ b/LK_RB_Synthesis/strategies/subtraction_decomposition_borrowing.py
@@ -1,0 +1,39 @@
+
+from src.automata.BaseAutomaton import BaseAutomaton
+from src.analysis.MUA_Metadata import StrategyMetadata
+
+class SubtractionDecompositionBorrowingAutomaton(BaseAutomaton):
+    _metadata = {
+        "Name": "Subtraction Decomposition (Borrowing)",
+        "Description": "Subtract higher place, detect insufficiency, borrow from higher unit, then subtract ones.",
+        "Cognitive Steps": ['q_init', 'q_sub_bases', 'q_check_ones', 'q_decompose', 'q_sub_ones'],
+        "Examples": []
+    }
+
+    @property
+    def metadata(self) -> StrategyMetadata:
+        return StrategyMetadata(**self._metadata)
+
+    def execute_q_start(self):
+        # Initial state logic
+        pass
+
+    def execute_q_init(self):
+        # Logic for init
+        pass
+
+    def execute_q_sub_bases(self):
+        # Logic for sub_bases
+        pass
+
+    def execute_q_check_ones(self):
+        # Logic for check_ones
+        pass
+
+    def execute_q_decompose(self):
+        # Logic for decompose
+        pass
+
+    def execute_q_sub_ones(self):
+        # Logic for sub_ones
+        pass

--- a/LK_RB_Synthesis/strategies/subtraction_rounding_and_adjusting.py
+++ b/LK_RB_Synthesis/strategies/subtraction_rounding_and_adjusting.py
@@ -1,0 +1,39 @@
+
+from src.automata.BaseAutomaton import BaseAutomaton
+from src.analysis.MUA_Metadata import StrategyMetadata
+
+class SubtractionRoundingAndAdjustingAutomaton(BaseAutomaton):
+    _metadata = {
+        "Name": "Subtraction Rounding and Adjusting",
+        "Description": "Dual rounding yields simplified M' - S', then contrasting compensations.",
+        "Cognitive Steps": ['q_start', 'q_roundM', 'q_roundS', 'q_subtract', 'q_adjustM', 'q_adjustS'],
+        "Examples": []
+    }
+
+    @property
+    def metadata(self) -> StrategyMetadata:
+        return StrategyMetadata(**self._metadata)
+
+    def execute_q_start(self):
+        # Initial state logic
+        pass
+
+    def execute_q_roundM(self):
+        # Logic for roundM
+        pass
+
+    def execute_q_roundS(self):
+        # Logic for roundS
+        pass
+
+    def execute_q_subtract(self):
+        # Logic for subtract
+        pass
+
+    def execute_q_adjustM(self):
+        # Logic for adjustM
+        pass
+
+    def execute_q_adjustS(self):
+        # Logic for adjustS
+        pass

--- a/LK_RB_Synthesis/strategies/subtraction_sliding_constant_difference.py
+++ b/LK_RB_Synthesis/strategies/subtraction_sliding_constant_difference.py
@@ -1,0 +1,31 @@
+
+from src.automata.BaseAutomaton import BaseAutomaton
+from src.analysis.MUA_Metadata import StrategyMetadata
+
+class SubtractionSlidingConstantDifferenceAutomaton(BaseAutomaton):
+    _metadata = {
+        "Name": "Subtraction Sliding (Constant Difference)",
+        "Description": "Find K so that S + K is a base number; compute (M + K) - (S + K).",
+        "Cognitive Steps": ['q_start', 'q_calcK', 'q_slide', 'q_subtract'],
+        "Examples": []
+    }
+
+    @property
+    def metadata(self) -> StrategyMetadata:
+        return StrategyMetadata(**self._metadata)
+
+    def execute_q_start(self):
+        # Initial state logic
+        pass
+
+    def execute_q_calcK(self):
+        # Logic for calcK
+        pass
+
+    def execute_q_slide(self):
+        # Logic for slide
+        pass
+
+    def execute_q_subtract(self):
+        # Logic for subtract
+        pass

--- a/LK_RB_Synthesis/strategies/using_commutative_reasoning_division.py
+++ b/LK_RB_Synthesis/strategies/using_commutative_reasoning_division.py
@@ -1,0 +1,31 @@
+
+from src.automata.BaseAutomaton import BaseAutomaton
+from src.analysis.MUA_Metadata import StrategyMetadata
+
+class UsingCommutativeReasoningDivisionAutomaton(BaseAutomaton):
+    _metadata = {
+        "Name": "Using Commutative Reasoning (Division)",
+        "Description": "For E / G: iteratively accumulate G until total E reached; iteration count is quotient.",
+        "Cognitive Steps": ['q_init', 'q_iterate', 'q_check'],
+        "Examples": []
+    }
+
+    @property
+    def metadata(self) -> StrategyMetadata:
+        return StrategyMetadata(**self._metadata)
+
+    def execute_q_start(self):
+        # Initial state logic
+        pass
+
+    def execute_q_init(self):
+        # Logic for init
+        pass
+
+    def execute_q_iterate(self):
+        # Logic for iterate
+        pass
+
+    def execute_q_check(self):
+        # Logic for check
+        pass


### PR DESCRIPTION
This change introduces a two-step pipeline to automatically generate Python skeleton files for cognitive strategies defined in a LaTeX document.

The pipeline consists of two scripts:
1.  `parse_latex.py`: Parses the `HC_GEM.tex` file to extract strategy information (name, description, cognitive steps) into a structured `strategies.json` file.
2.  `generate_skeletons.py`: Reads the `strategies.json` file and generates Python skeleton classes for each strategy. These classes inherit from `BaseAutomaton` and include placeholder methods for the cognitive steps.

This automation significantly speeds up the process of creating new strategy implementations, reducing manual effort and ensuring a consistent structure.